### PR TITLE
Made fixedUrls const

### DIFF
--- a/core/httpd.c
+++ b/core/httpd.c
@@ -19,7 +19,7 @@ Esp8266 http server - core routines
 #include "httpd-platform.h"
 
 //This gets set at init time.
-static HttpdBuiltInUrl *builtInUrls;
+static const HttpdBuiltInUrl *builtInUrls;
 
 typedef struct HttpSendBacklogItem HttpSendBacklogItem;
 
@@ -850,7 +850,7 @@ int ICACHE_FLASH_ATTR httpdConnectCb(ConnTypePtr conn, char *remIp, int remPort)
 }
 
 //Httpd initialization routine. Call this to kick off webserver functionality.
-void ICACHE_FLASH_ATTR httpdInit(HttpdBuiltInUrl *fixedUrls, int port) {
+void ICACHE_FLASH_ATTR httpdInit(const HttpdBuiltInUrl *fixedUrls, int port) {
 	int i;
 
 	for (i=0; i<HTTPD_MAX_CONNECTIONS; i++) {

--- a/include/libesphttpd/httpd.h
+++ b/include/libesphttpd/httpd.h
@@ -79,7 +79,7 @@ int cgiRedirectApClientToHostname(HttpdConnData *connData);
 void httpdRedirect(HttpdConnData *conn, char *newUrl);
 int httpdUrlDecode(char *val, int valLen, char *ret, int retLen);
 int httpdFindArg(char *line, char *arg, char *buff, int buffLen);
-void httpdInit(HttpdBuiltInUrl *fixedUrls, int port);
+void httpdInit(const HttpdBuiltInUrl *fixedUrls, int port);
 const char *httpdGetMimetype(char *url);
 void httdSetTransferMode(HttpdConnData *conn, int mode);
 void httpdStartResponse(HttpdConnData *conn, int code);


### PR DESCRIPTION
Added a const specifier to fixedUrls parameter of
httpdInit to be able to store fixed URLs in flash memory.