### PR TITLE
 fixed cgiWiFiScan with 32B ssids

### DIFF
--- a/util/cgiwifi.c
+++ b/util/cgiwifi.c
@@ -138,7 +138,7 @@ int cgiWiFiScan(HttpdConnData *connData) {
 	if (!cgiWifiAps.scanInProgress && pos!=0) {
 		//Fill in json code for an access point
 		if (pos-1<cgiWifiAps.noAps) {
-			len=sprintf(buff, "{\"essid\": \"%s\", \"bssid\": \"" MACSTR "\", \"rssi\": \"%d\", \"enc\": \"%d\", \"channel\": \"%d\"}%s\n",
+			len=sprintf(buff, "{\"essid\": \"%.32s\", \"bssid\": \"" MACSTR "\", \"rssi\": \"%d\", \"enc\": \"%d\", \"channel\": \"%d\"}%s\n",
 					cgiWifiAps.apData[pos-1]->ssid, MAC2STR(cgiWifiAps.apData[pos-1]->bssid), cgiWifiAps.apData[pos-1]->rssi,
 					cgiWifiAps.apData[pos-1]->enc, cgiWifiAps.apData[pos-1]->channel, (pos-1==cgiWifiAps.noAps-1)?"":",");
 			httpdSend(connData, buff, len);


### PR DESCRIPTION
Fixes an issue where pages made with cgiWiFiScan returned extra characters (from bssid and probably beyond) at the end of ssid if said ssid had 32 characters. For example network named '01234567890123456789012345678901' could be reported as:
```
{"essid": "012345678901234567890123456789018C}Ž:2¥¥", "bssid": "38:43:7d:8e:3a:32", "rssi": "191", "enc": "3", "channel": "6"}
```